### PR TITLE
Add grid bot module and comprehensive pytest suite

### DIFF
--- a/bot_ia_grid/__init__.py
+++ b/bot_ia_grid/__init__.py
@@ -1,0 +1,10 @@
+"""Grid trading bot utilities."""
+
+from .grid_bot import GridBot, GridOrder, Trade, InsufficientBalanceError
+
+__all__ = [
+    "GridBot",
+    "GridOrder",
+    "Trade",
+    "InsufficientBalanceError",
+]

--- a/bot_ia_grid/grid_bot.py
+++ b/bot_ia_grid/grid_bot.py
@@ -1,0 +1,196 @@
+"""Core logic for a simple geometric grid trading bot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Literal, Optional
+
+
+Side = Literal["buy", "sell"]
+
+
+class GridBotError(Exception):
+    """Base exception for the grid bot module."""
+
+
+class InsufficientBalanceError(GridBotError):
+    """Raised when an order cannot be executed due to insufficient balance."""
+
+    def __init__(self, side: Side, required: float, available: float) -> None:
+        super().__init__(
+            f"Insufficient {side} balance: required {required:.8f}, available {available:.8f}."
+        )
+        self.side = side
+        self.required = required
+        self.available = available
+
+
+@dataclass
+class GridOrder:
+    """Represents an order placed on the grid."""
+
+    side: Side
+    price: float
+    quantity: float
+    executed: bool = False
+
+
+@dataclass
+class Trade:
+    """Data captured after executing a trade."""
+
+    side: Side
+    price: float
+    quantity: float
+    fee_paid: float
+    executed_price: float
+
+    @property
+    def slippage(self) -> float:
+        """Return the absolute slippage applied to the order."""
+
+        if self.side == "buy":
+            return self.executed_price - self.price
+        return self.price - self.executed_price
+
+
+class GridBot:
+    """Implements a very small grid trading strategy for spot markets."""
+
+    def __init__(
+        self,
+        base_price: float,
+        levels: int,
+        ratio: float,
+        quantity_per_order: float,
+        base_balance: float,
+        quote_balance: float,
+        fee_rate: float = 0.001,
+        slippage: float = 0.0,
+    ) -> None:
+        self._validate_inputs(
+            base_price,
+            levels,
+            ratio,
+            quantity_per_order,
+            base_balance,
+            quote_balance,
+            fee_rate,
+            slippage,
+        )
+
+        self.base_price = base_price
+        self.levels = levels
+        self.ratio = ratio
+        self.quantity_per_order = quantity_per_order
+        self.base_balance = base_balance
+        self.quote_balance = quote_balance
+        self.fee_rate = fee_rate
+        self.slippage = slippage
+
+        self.orders: List[GridOrder] = self._build_orders()
+        self.trade_history: List[Trade] = []
+
+    @staticmethod
+    def _validate_inputs(
+        base_price: float,
+        levels: int,
+        ratio: float,
+        quantity_per_order: float,
+        base_balance: float,
+        quote_balance: float,
+        fee_rate: float,
+        slippage: float,
+    ) -> None:
+        if base_price <= 0:
+            raise ValueError("base_price must be greater than zero.")
+        if levels < 1:
+            raise ValueError("levels must be at least one.")
+        if ratio <= 1.0:
+            raise ValueError("ratio must be greater than 1 to build a geometric grid.")
+        if quantity_per_order <= 0:
+            raise ValueError("quantity_per_order must be greater than zero.")
+        if base_balance < 0:
+            raise ValueError("base_balance cannot be negative.")
+        if quote_balance < 0:
+            raise ValueError("quote_balance cannot be negative.")
+        if fee_rate < 0:
+            raise ValueError("fee_rate cannot be negative.")
+        if slippage < 0:
+            raise ValueError("slippage cannot be negative.")
+
+    def _build_orders(self) -> List[GridOrder]:
+        orders: List[GridOrder] = []
+        for level in range(1, self.levels + 1):
+            buy_price = self.base_price / (self.ratio**level)
+            sell_price = self.base_price * (self.ratio**level)
+            orders.append(GridOrder("buy", buy_price, self.quantity_per_order))
+            orders.append(GridOrder("sell", sell_price, self.quantity_per_order))
+        # Keep buy orders sorted descending (closest to base price first)
+        buy_orders = sorted((o for o in orders if o.side == "buy"), key=lambda o: o.price, reverse=True)
+        sell_orders = sorted((o for o in orders if o.side == "sell"), key=lambda o: o.price)
+        return buy_orders + sell_orders
+
+    def iter_orders(self, side: Optional[Side] = None) -> Iterable[GridOrder]:
+        """Yield orders filtered by side while preserving configured ordering."""
+
+        if side is None:
+            yield from self.orders
+        else:
+            yield from (order for order in self.orders if order.side == side)
+
+    def process_price(self, price: float) -> List[Trade]:
+        """Process a market tick, executing any orders that become eligible."""
+
+        if price <= 0:
+            raise ValueError("price must be greater than zero for processing.")
+
+        trades: List[Trade] = []
+        for order in self.orders:
+            if order.executed:
+                continue
+            if order.side == "buy" and price <= order.price:
+                trades.append(self._execute_order(order))
+            elif order.side == "sell" and price >= order.price:
+                trades.append(self._execute_order(order))
+        return trades
+
+    def _execute_order(self, order: GridOrder) -> Trade:
+        quantity = order.quantity
+        if order.side == "buy":
+            executed_price = order.price * (1 + self.slippage)
+            gross_cost = executed_price * quantity
+            fee_paid = gross_cost * self.fee_rate
+            total_cost = gross_cost + fee_paid
+            if total_cost - self.quote_balance > 1e-12:
+                raise InsufficientBalanceError("buy", total_cost, self.quote_balance)
+            self.quote_balance -= total_cost
+            self.base_balance += quantity
+        else:
+            executed_price = order.price * (1 - self.slippage)
+            if quantity - self.base_balance > 1e-12:
+                raise InsufficientBalanceError("sell", quantity, self.base_balance)
+            gross_proceeds = executed_price * quantity
+            fee_paid = gross_proceeds * self.fee_rate
+            self.base_balance -= quantity
+            self.quote_balance += gross_proceeds - fee_paid
+
+        order.executed = True
+        trade = Trade(order.side, order.price, quantity, fee_paid, executed_price)
+        self.trade_history.append(trade)
+        return trade
+
+    def outstanding_orders(self, side: Optional[Side] = None) -> List[GridOrder]:
+        """Return a snapshot of outstanding (non executed) orders."""
+
+        if side is None:
+            return [order for order in self.orders if not order.executed]
+        return [order for order in self.orders if order.side == side and not order.executed]
+
+    def reset(self) -> None:
+        """Reset order execution flags and clear trade history."""
+
+        for order in self.orders:
+            order.executed = False
+        self.trade_history.clear()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+"""Pytest fixtures for grid bot testing."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_ia_grid import GridBot
+
+
+@pytest.fixture
+def grid_bot_liquid() -> GridBot:
+    """Bot with enough balances to cover both buy and sell operations."""
+
+    return GridBot(
+        base_price=100.0,
+        levels=3,
+        ratio=1.05,
+        quantity_per_order=0.2,
+        base_balance=1.5,
+        quote_balance=2000.0,
+        fee_rate=0.001,
+        slippage=0.002,
+    )
+
+
+@pytest.fixture
+def price_series_up_down() -> list[float]:
+    """Synthetic series with alternating dips and spikes."""
+
+    return [102.0, 96.0, 107.0, 93.0, 111.0]
+
+
+@pytest.fixture
+def grid_bot_low_quote() -> GridBot:
+    """Bot that cannot execute buy orders due to lack of quote balance."""
+
+    return GridBot(
+        base_price=100.0,
+        levels=1,
+        ratio=1.04,
+        quantity_per_order=0.5,
+        base_balance=0.5,
+        quote_balance=10.0,
+        fee_rate=0.001,
+        slippage=0.001,
+    )
+
+
+@pytest.fixture
+def grid_bot_low_base() -> GridBot:
+    """Bot that cannot execute sell orders due to lack of base balance."""
+
+    return GridBot(
+        base_price=100.0,
+        levels=1,
+        ratio=1.04,
+        quantity_per_order=1.0,
+        base_balance=0.2,
+        quote_balance=500.0,
+        fee_rate=0.001,
+        slippage=0.001,
+    )
+

--- a/tests/test_geometric_levels.py
+++ b/tests/test_geometric_levels.py
@@ -1,0 +1,46 @@
+"""Tests for geometric grid level generation."""
+
+import math
+
+from bot_ia_grid import GridBot
+
+
+def test_geometric_progression_structure() -> None:
+    bot = GridBot(
+        base_price=25000.0,
+        levels=4,
+        ratio=1.03,
+        quantity_per_order=0.05,
+        base_balance=2.0,
+        quote_balance=50000.0,
+        fee_rate=0.0005,
+        slippage=0.001,
+    )
+
+    buy_prices = [order.price for order in bot.iter_orders("buy")]
+    sell_prices = [order.price for order in bot.iter_orders("sell")]
+
+    assert buy_prices == sorted(buy_prices, reverse=True)
+    assert sell_prices == sorted(sell_prices)
+
+    for previous, current in zip(buy_prices, buy_prices[1:]):
+        ratio = previous / current
+        assert math.isclose(ratio, bot.ratio, rel_tol=1e-9)
+
+    for previous, current in zip(sell_prices, sell_prices[1:]):
+        ratio = current / previous
+        assert math.isclose(ratio, bot.ratio, rel_tol=1e-9)
+
+    assert buy_prices[-1] < bot.base_price < sell_prices[0]
+
+
+def test_geometric_levels_remain_constant_after_processing(grid_bot_liquid) -> None:
+    initial_buy_prices = [order.price for order in grid_bot_liquid.iter_orders("buy")]
+
+    grid_bot_liquid.process_price(90.0)
+    grid_bot_liquid.process_price(120.0)
+
+    post_buy_prices = [order.price for order in grid_bot_liquid.iter_orders("buy")]
+
+    assert initial_buy_prices == post_buy_prices
+

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,58 @@
+"""Input validation tests for the GridBot."""
+
+import pytest
+
+from bot_ia_grid import GridBot
+
+
+@pytest.mark.parametrize(
+    "base_price, levels, ratio, quantity, base_balance, quote_balance, fee_rate, slippage, error_message",
+    [
+        (0, 1, 1.02, 0.1, 1, 100, 0.001, 0.0, "base_price"),
+        (100, 0, 1.02, 0.1, 1, 100, 0.001, 0.0, "levels"),
+        (100, 1, 1.0, 0.1, 1, 100, 0.001, 0.0, "ratio"),
+        (100, 1, 1.02, 0.0, 1, 100, 0.001, 0.0, "quantity_per_order"),
+        (100, 1, 1.02, 0.1, -1, 100, 0.001, 0.0, "base_balance"),
+        (100, 1, 1.02, 0.1, 1, -10, 0.001, 0.0, "quote_balance"),
+        (100, 1, 1.02, 0.1, 1, 100, -0.001, 0.0, "fee_rate"),
+        (100, 1, 1.02, 0.1, 1, 100, 0.001, -0.1, "slippage"),
+    ],
+)
+def test_constructor_validates_inputs(
+    base_price,
+    levels,
+    ratio,
+    quantity,
+    base_balance,
+    quote_balance,
+    fee_rate,
+    slippage,
+    error_message,
+) -> None:
+    with pytest.raises(ValueError) as exc:
+        GridBot(
+            base_price=base_price,
+            levels=levels,
+            ratio=ratio,
+            quantity_per_order=quantity,
+            base_balance=base_balance,
+            quote_balance=quote_balance,
+            fee_rate=fee_rate,
+            slippage=slippage,
+        )
+
+    assert error_message in str(exc.value)
+
+
+def test_reset_clears_trade_history(grid_bot_liquid, price_series_up_down) -> None:
+    for price in price_series_up_down:
+        grid_bot_liquid.process_price(price)
+
+    assert grid_bot_liquid.trade_history
+    assert any(order.executed for order in grid_bot_liquid.orders)
+
+    grid_bot_liquid.reset()
+
+    assert not grid_bot_liquid.trade_history
+    assert all(not order.executed for order in grid_bot_liquid.orders)
+

--- a/tests/test_operation_logging.py
+++ b/tests/test_operation_logging.py
@@ -1,0 +1,29 @@
+"""Operation logging validations for the grid bot."""
+
+from bot_ia_grid import GridBot
+
+
+def test_trade_history_records_side_price_and_slippage(grid_bot_liquid, price_series_up_down) -> None:
+    for price in price_series_up_down:
+        grid_bot_liquid.process_price(price)
+
+    trades = grid_bot_liquid.trade_history
+    assert trades, "Expected at least one trade to be recorded"
+
+    for trade in trades:
+        assert trade.side in {"buy", "sell"}
+        assert trade.quantity == grid_bot_liquid.quantity_per_order
+        assert trade.fee_paid >= 0
+        assert trade.executed_price > 0
+        assert trade.slippage >= 0
+
+
+def test_trade_history_preserves_execution_sequence(grid_bot_liquid) -> None:
+    first_leg_price = next(order.price for order in grid_bot_liquid.iter_orders("buy"))
+    second_leg_price = next(order.price for order in grid_bot_liquid.iter_orders("sell"))
+
+    grid_bot_liquid.process_price(first_leg_price * 0.999)
+    grid_bot_liquid.process_price(second_leg_price * 1.001)
+
+    assert [trade.side for trade in grid_bot_liquid.trade_history] == ["buy", "sell"]
+

--- a/tests/test_spot_logic.py
+++ b/tests/test_spot_logic.py
@@ -1,0 +1,38 @@
+"""Spot trading behaviour tests ensuring balances remain non-negative."""
+
+import pytest
+
+from bot_ia_grid import InsufficientBalanceError
+
+
+def test_balances_never_negative(grid_bot_liquid, price_series_up_down) -> None:
+    for price in price_series_up_down:
+        grid_bot_liquid.process_price(price)
+        assert grid_bot_liquid.base_balance >= 0
+        assert grid_bot_liquid.quote_balance >= 0
+
+    assert grid_bot_liquid.trade_history, "No trades were executed in the scenario"
+
+
+def test_execute_buy_requires_quote_balance(grid_bot_low_quote) -> None:
+    buy_order = next(order for order in grid_bot_low_quote.iter_orders("buy"))
+
+    with pytest.raises(InsufficientBalanceError):
+        grid_bot_low_quote.process_price(buy_order.price)
+
+    assert not grid_bot_low_quote.trade_history
+
+
+def test_execute_sell_requires_base_balance(grid_bot_low_base) -> None:
+    sell_order = next(order for order in grid_bot_low_base.iter_orders("sell"))
+
+    with pytest.raises(InsufficientBalanceError):
+        grid_bot_low_base.process_price(sell_order.price)
+
+    assert not grid_bot_low_base.trade_history
+
+
+def test_process_price_rejects_invalid_tick(grid_bot_liquid) -> None:
+    with pytest.raises(ValueError):
+        grid_bot_liquid.process_price(0)
+


### PR DESCRIPTION
## Summary
- implement a minimal grid trading bot with order execution, balance checks and trade logging
- expose fixtures and synthetic market scenarios covering price swings, fees, slippage and insufficient funds
- add a pytest configuration via pyproject.toml and create tests for geometric levels, spot logic, logging and validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5daade4b8832ea746ee5c29354182